### PR TITLE
Rewrite IOController for HitL system to use FT4222 chip

### DIFF
--- a/hardware_in_the_loop/software/README.md
+++ b/hardware_in_the_loop/software/README.md
@@ -52,6 +52,8 @@ This is a work in progress! It is not at all functional yet, but the current goa
 
 * [pyenv](https://realpython.com/intro-to-pyenv/)
 
+* [ft4222 python library](https://msrelectronics.gitlab.io/python-ft4222/)
+
 
 If you go to Olin, the fastest way to get help is probably to hit up our Slack channel, `#hardware_in_the_loop`. Otherwise, you can email awenstrup@olin.edu
 

--- a/hardware_in_the_loop/software/artifacts/config.ini
+++ b/hardware_in_the_loop/software/artifacts/config.ini
@@ -11,7 +11,6 @@ can_bitrate=500000
 can_channel=can0
 
 [PATHS]
-serial_path=/dev/arduino
 pin_config=pin_info.csv
 dbc_path=dash.dbc
 can_log_path=None  # TODO not supported yet

--- a/hardware_in_the_loop/software/artifacts/config.ini
+++ b/hardware_in_the_loop/software/artifacts/config.ini
@@ -8,7 +8,7 @@ log_path=None # $LOGS/$DATETIME.log
 
 [HARDWARE]
 can_bitrate=500000
-can_channel=can0
+can_channel=vcan0
 
 [PATHS]
 pin_config=pin_info.csv

--- a/hardware_in_the_loop/software/artifacts/pin_info.csv
+++ b/hardware_in_the_loop/software/artifacts/pin_info.csv
@@ -1,39 +1,38 @@
-Address ,Board ,Pin Number ,System      ,Name                 ,Type    ,Set/Get ,Min ,Max    ,Notes
-0       ,0     ,0          ,NONE        ,ERROR                ,DIGITAL ,        ,0   ,1      ,Sent as response from HitL system interface if there was an error
-1       ,0     ,0          ,COCKPIT     ,SS_BOTS              ,DIGITAL ,GET     ,0   ,1      ,
-2       ,0     ,0          ,COCKPIT     ,SS_INERTIA_SWITCH    ,DIGITAL ,GET     ,0   ,1      ,
-3       ,0     ,0          ,COCKPIT     ,SS_COCKPIT_ESTOP     ,DIGITAL ,GET     ,0   ,1      ,
-4       ,0     ,0          ,COCKPIT     ,STEERING_POT         ,ANALOG  ,SET     ,0   ,5      ,
-5       ,0     ,0          ,COCKPIT     ,THROTTLE_POT_1       ,ANALOG  ,SET     ,0   ,5      ,
-6       ,0     ,0          ,COCKPIT     ,THROTTLE_POT_2       ,ANALOG  ,SET     ,0   ,5      ,
-7       ,0     ,0          ,COCKPIT     ,RTD_LSD              ,DIGITAL ,        ,0   ,1      ,"Little confused on this one, plz ping @Alex Wenstrup"
-8       ,0     ,0          ,LV_BOX      ,BRAKE_PRESSURE       ,ANALOG  ,GET     ,0   ,5      ,Not sure if 0-5
-9       ,0     ,0          ,LV_BOX      ,BRAKE_LIGHT          ,DIGITAL ,GET     ,0   ,1      ,
-10      ,0     ,0          ,LV_BOX      ,SS_GLVMS             ,DIGITAL ,GET     ,0   ,1      ,
-11      ,0     ,0          ,LV_BOX      ,SS_TSMS              ,DIGITAL ,GET     ,0   ,1      ,
-12      ,0     ,0          ,LV_BOX      ,SS_ESTOP             ,DIGITAL ,GET     ,0   ,1      ,
-13      ,0     ,0          ,LV_BOX      ,SS_BSPD              ,DIGITAL ,GET     ,0   ,1      ,Add temp sensors
-14      ,0     ,0          ,ACCUMULATOR ,SS_BMS               ,DIGITAL ,GET     ,0   ,1      ,Not sure how the AIRs are hooked up
-15      ,0     ,0          ,ACCUMULATOR ,SS_IMD               ,DIGITAL ,GET     ,0   ,1      ,
-16      ,0     ,0          ,ACCUMULATOR ,TSAL                 ,DIGITAL ,GET     ,0   ,1      ,"Little confused on this one, plz ping @Alex Wenstrup"
-17      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_1  ,ANALOG  ,        ,2.5 ,2.5008 ,
-18      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_2  ,ANALOG  ,        ,2.5 ,2.5008 ,
-19      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_3  ,ANALOG  ,        ,2.5 ,2.5008 ,
-20      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_4  ,ANALOG  ,        ,2.5 ,2.5008 ,
-21      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_5  ,ANALOG  ,        ,2.5 ,2.5008 ,
-22      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_6  ,ANALOG  ,        ,2.5 ,2.5008 ,
-23      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_7  ,ANALOG  ,        ,2.5 ,2.5008 ,
-24      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_8  ,ANALOG  ,        ,2.5 ,2.5008 ,
-25      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_9  ,ANALOG  ,        ,2.5 ,2.5008 ,
-26      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_10 ,ANALOG  ,        ,2.5 ,2.5008 ,
-27      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_11 ,ANALOG  ,        ,2.5 ,2.5008 ,
-28      ,0     ,0          ,SENSING     ,SUSPENSION_STRAIN_12 ,ANALOG  ,        ,2.5 ,2.5008 ,
-29      ,0     ,0          ,SENSING     ,WHEEL_SPEED_1        ,DIGITAL ,        ,0   ,1      ,Format of this?
-30      ,0     ,0          ,SENSING     ,WHEEL_SPEED_2        ,DIGITAL ,        ,0   ,1      ,
-31      ,0     ,0          ,SENSING     ,WHEEL_SPEED_3        ,DIGITAL ,        ,0   ,1      ,
-32      ,0     ,0          ,SENSING     ,WHEEL_SPEED_4        ,DIGITAL ,        ,0   ,1      ,
-33      ,0     ,0          ,SENSING     ,SUSPENSION_TRAVEL_1  ,ANALOG  ,        ,0   ,5      ,
-34      ,0     ,0          ,SENSING     ,SUSPENSION_TRAVEL_2  ,ANALOG  ,        ,0   ,5      ,
-35      ,0     ,0          ,SENSING     ,SUSPENSION_TRAVEL_3  ,ANALOG  ,        ,0   ,5      ,
-36      ,0     ,0          ,SENSING     ,SUSPENSION_TRAVEL_4  ,ANALOG  ,        ,0   ,5      ,
-
+Address ,Pin Number ,Name                 ,Type    ,Read/Write ,Min ,Max    ,Notes
+0       ,0          ,ERROR                ,DIGITAL ,           ,0   ,1      ,Sent as response from HitL system interface if there was an error
+1       ,0          ,SS_BOTS              ,DIGITAL ,READ       ,0   ,1      ,
+2       ,0          ,SS_INERTIA_SWITCH    ,DIGITAL ,READ       ,0   ,1      ,
+3       ,0          ,SS_COCKPIT_ESTOP     ,DIGITAL ,READ       ,0   ,1      ,
+4       ,0          ,STEERING_POT         ,ANALOG  ,WRITE      ,0   ,5      ,
+5       ,0          ,THROTTLE_POT_1       ,ANALOG  ,WRITE      ,0   ,5      ,
+6       ,0          ,THROTTLE_POT_2       ,ANALOG  ,WRITE      ,0   ,5      ,
+7       ,0          ,RTD_LSD              ,DIGITAL ,           ,0   ,1      ,"Little confused on this one, plz ping @Alex Wenstrup"
+8       ,0          ,BRAKE_PRESSURE       ,ANALOG  ,READ       ,0   ,5      ,Not sure if 0-5
+9       ,0          ,BRAKE_LIGHT          ,DIGITAL ,READ       ,0   ,1      ,
+10      ,0          ,SS_GLVMS             ,DIGITAL ,READ       ,0   ,1      ,
+11      ,0          ,SS_TSMS              ,DIGITAL ,READ       ,0   ,1      ,
+12      ,0          ,SS_ESTOP             ,DIGITAL ,READ       ,0   ,1      ,
+13      ,0          ,SS_BSPD              ,DIGITAL ,READ       ,0   ,1      ,Add temp sensors
+14      ,0          ,SS_BMS               ,DIGITAL ,READ       ,0   ,1      ,Not sure how the AIRs are hooked up
+15      ,0          ,SS_IMD               ,DIGITAL ,READ       ,0   ,1      ,
+16      ,0          ,TSAL                 ,DIGITAL ,READ       ,0   ,1      ,"Little confused on this one, plz ping @Alex Wenstrup"
+17      ,0          ,SUSPENSION_STRAIN_1  ,ANALOG  ,           ,2.5 ,2.5008 ,
+18      ,0          ,SUSPENSION_STRAIN_2  ,ANALOG  ,           ,2.5 ,2.5008 ,
+19      ,0          ,SUSPENSION_STRAIN_3  ,ANALOG  ,           ,2.5 ,2.5008 ,
+20      ,0          ,SUSPENSION_STRAIN_4  ,ANALOG  ,           ,2.5 ,2.5008 ,
+21      ,0          ,SUSPENSION_STRAIN_5  ,ANALOG  ,           ,2.5 ,2.5008 ,
+22      ,0          ,SUSPENSION_STRAIN_6  ,ANALOG  ,           ,2.5 ,2.5008 ,
+23      ,0          ,SUSPENSION_STRAIN_7  ,ANALOG  ,           ,2.5 ,2.5008 ,
+24      ,0          ,SUSPENSION_STRAIN_8  ,ANALOG  ,           ,2.5 ,2.5008 ,
+25      ,0          ,SUSPENSION_STRAIN_9  ,ANALOG  ,           ,2.5 ,2.5008 ,
+26      ,0          ,SUSPENSION_STRAIN_10 ,ANALOG  ,           ,2.5 ,2.5008 ,
+27      ,0          ,SUSPENSION_STRAIN_11 ,ANALOG  ,           ,2.5 ,2.5008 ,
+28      ,0          ,SUSPENSION_STRAIN_12 ,ANALOG  ,           ,2.5 ,2.5008 ,
+29      ,0          ,WHEEL_SPEED_1        ,DIGITAL ,           ,0   ,1      ,Format of this?
+30      ,0          ,WHEEL_SPEED_2        ,DIGITAL ,           ,0   ,1      ,
+31      ,0          ,WHEEL_SPEED_3        ,DIGITAL ,           ,0   ,1      ,
+32      ,0          ,WHEEL_SPEED_4        ,DIGITAL ,           ,0   ,1      ,
+33      ,0          ,SUSPENSION_TRAVEL_1  ,ANALOG  ,           ,0   ,5      ,
+34      ,0          ,SUSPENSION_TRAVEL_2  ,ANALOG  ,           ,0   ,5      ,
+35      ,0          ,SUSPENSION_TRAVEL_3  ,ANALOG  ,           ,0   ,5      ,
+36      ,0          ,SUSPENSION_TRAVEL_4  ,ANALOG  ,           ,0   ,5      ,

--- a/hardware_in_the_loop/software/docs/make_cmd_list.py
+++ b/hardware_in_the_loop/software/docs/make_cmd_list.py
@@ -34,27 +34,31 @@ OUTPUT_PATH = os.path.join(artifacts_path, "cmd_list.md")
 def generate_header() -> str:
     return HEADER
 
+
 def generate_footer() -> str:
     return FOOTER
+
 
 def generate_io_command(signal: str, kind: str) -> str:
     out = ""
 
-    if (kind == "SET") or (kind == "BOTH") :
+    if (kind == "SET") or (kind == "BOTH"):
         out += f"To set {signal} to `value`, you can run `harness.io.set_state({signal}, value)`\n\n"
 
-    if (kind == "GET") or (kind == "BOTH") :
+    if (kind == "GET") or (kind == "BOTH"):
         out += f"To get {signal}, you can run `harness.io.get_state({signal})`\n\n"
 
     return out
 
+
 def generate_can_command(signal: str) -> str:
     return f"To get {signal}, you can run `harness.can.set_state({signal})`\n\n"
+
 
 def generate_all_io_commands(filepath: str) -> str:
     out = ""
 
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         line = f.readline()  # clear the header line
         line = f.readline()  # get the first data line ready
         while line != "":  # keep reading until we hit the end
@@ -68,14 +72,17 @@ def generate_all_io_commands(filepath: str) -> str:
 
     return out
 
+
 def generate_all_can_commands(filepath: str) -> str:
     # TODO
     return ""
 
+
 def write_to_file(filepath: str, data: str) -> None:
     """Write a string to a file"""
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         f.write(data)
+
 
 # Main function
 if __name__ == "__main__":
@@ -87,4 +94,3 @@ if __name__ == "__main__":
     output += generate_footer()
 
     write_to_file(OUTPUT_PATH, output)
-    

--- a/hardware_in_the_loop/software/docs/source/config.rst
+++ b/hardware_in_the_loop/software/docs/source/config.rst
@@ -32,9 +32,6 @@ PATHS
 ^^^^^
 This section should be pretty self explanatory; these are the paths the project uses to look for files and devices. These paths should be consumed by the top-level testing object (for example, a ``RoadkillHarness``), and passed from there to the objects that need them (for example, an ``IOController``).
 
-serial_path:
-    The path a serial device. If you've run ``hardware_setup.py`` (and rebooted), there should be a symbolic link from your arduino to ``/dev/arduino``.
-
 pin_config:
     The path the pin config file (relative to the ``artifacts`` directory). This file is documented in more detail on the ``IOController`` page. For example, if your pin config file is at ``artifacts/pin_info.csv``, use ``pin_info.csv`` (NOT ``~/AdvancedResearch/hardware_in_the_loop/software/artifacts/pin_info.csv``)
 

--- a/hardware_in_the_loop/software/docs/source/setup.rst
+++ b/hardware_in_the_loop/software/docs/source/setup.rst
@@ -15,19 +15,21 @@ Installation
 
     $ git clone https://github.com/olin-electric-motorsports/AdvancedResearch.git
 
-2. To perform software installation and setup, navigate to the software directory::
+2. Install drivers for the FTDI chip from `here <https://ftdichip.com/drivers/d2xx-drivers/>`_ and follow the instructions in the ``ReadMe.rtf`` file.
+
+3. To perform software installation and setup, navigate to the software directory::
     
     $ cd AdvancedResearch/hardware_in_the_loop/software
 
-3. (Optional) If you want to setup a virtual environment for this project (I recommend it), now is the time. If you don't know how to do this, read `here <https://realpython.com/intro-to-pyenv/>`_
+4. (Optional) If you want to setup a virtual environment for this project (I recommend it), now is the time. If you don't know how to do this, read `here <https://realpython.com/intro-to-pyenv/>`_
 
-4. Use pip to install the project and its dependencies on your computer. If you usually use ``pip3`` to invoke ``pip``, use that instead; as long as the actual version of ``pip`` is >3.6.0, you should be fine.::
+5. Use pip to install the project and its dependencies on your computer. If you usually use ``pip3`` to invoke ``pip``, use that instead; as long as the actual version of ``pip`` is >3.6.0, you should be fine.::
 
     $ pip install -e .
 
-5. Now that the software is installed, it's time to configure hardware. For now, the only hardware we can connect to is an arduino. Go ahead and plug that in now. If you don't have an arduino, thats fine; you just won't be able to run all unit tests.
+6. Now that the software is installed, it's time to configure hardware. For now, the only hardware we can connect to is an arduino. Go ahead and plug that in now. If you don't have an arduino, thats fine; you just won't be able to run all unit tests.
 
-6. Now that your arduino is plugged in, verify that your computer recognizes it with::
+7. Now that your arduino is plugged in, verify that your computer recognizes it with::
 
     `$ lsusb`
     

--- a/hardware_in_the_loop/software/hitl/cancontroller.py
+++ b/hardware_in_the_loop/software/hitl/cancontroller.py
@@ -32,7 +32,9 @@ class CANController:
     :param int bitrate: The bitrate of the can bus. Defaults to 500K If using a virtual bus, you can ignore this.
     """
 
-    def __init__(self, ecus: dict, can_spec_path: str, channel: str, bitrate: int = 500000):
+    def __init__(
+        self, ecus: dict, can_spec_path: str, channel: str, bitrate: int = 500000
+    ):
         # Create logger (all config should already be set by RoadkillHarness)
         self.log = logging.getLogger(name=__name__)
 
@@ -44,9 +46,13 @@ class CANController:
                 os.system(f"sudo ip link add dev {channel} type vcan")
                 os.system(f"sudo ip link set {channel} up")  # virtual hardware
             else:
-                os.system(f"sudo ip link set {channel} up type can bitrate {bitrate} restart-ms 100")  # real hardware
+                os.system(
+                    f"sudo ip link set {channel} up type can bitrate {bitrate} restart-ms 100"
+                )  # real hardware
         else:
-            self.log.error("Cannot bring up real or fake can hardware; must be on linux.")
+            self.log.error(
+                "Cannot bring up real or fake can hardware; must be on linux."
+            )
 
         self.ecus = ecus
         self.read_dict = {}  # Dictionary to help translate raw can to useful signals
@@ -55,12 +61,18 @@ class CANController:
         # Start listening
         bus_type = "socketcan"
         if "linux" in sys.platform:
-            can_bus = can.interface.Bus(channel=channel, bus_type=bus_type, bitrate=bitrate)
+            can_bus = can.interface.Bus(
+                channel=channel, bus_type=bus_type, bitrate=bitrate
+            )
             self.kill_threads = threading.Event()
             listener = threading.Thread(
                 target=self._listen,
                 name="listener",
-                kwargs={"can_bus": can_bus, "callback": self._update_ecu, "kill_threads": self.kill_threads},
+                kwargs={
+                    "can_bus": can_bus,
+                    "callback": self._update_ecu,
+                    "kill_threads": self.kill_threads,
+                },
             )
             listener.start()
         else:
@@ -91,10 +103,14 @@ class CANController:
             for signal in msg.signals:
                 for sender in msg.senders:
                     try:
-                        self.ecus[sender].states[signal.name] = None  # TODO Idk what to use for default values...
+                        self.ecus[sender].states[
+                            signal.name
+                        ] = None  # TODO Idk what to use for default values...
                     except Exception as e:
                         self.log.error(e)
-                        self.log.error(f"Could not add signal {signal} to sender {sender}")
+                        self.log.error(
+                            f"Could not add signal {signal} to sender {sender}"
+                        )
 
     def __del__(self):
         """Destructor (called when the program ends)
@@ -104,7 +120,9 @@ class CANController:
         if hasattr(self, "kill_threads"):
             self.kill_threads.set()
 
-    def _listen(self, can_bus: can.Bus, callback: Callable, kill_threads: threading.Event) -> None:
+    def _listen(
+        self, can_bus: can.Bus, callback: Callable, kill_threads: threading.Event
+    ) -> None:
         """Thread that runs all the time to listen to CAN messages
 
         References:

--- a/hardware_in_the_loop/software/hitl/cancontroller.py
+++ b/hardware_in_the_loop/software/hitl/cancontroller.py
@@ -62,7 +62,7 @@ class CANController:
         bus_type = "socketcan"
         if "linux" in sys.platform:
             can_bus = can.interface.Bus(
-                channel=channel, bus_type=bus_type, bitrate=bitrate
+                channel=channel, bustype=bus_type, bitrate=bitrate
             )
             self.kill_threads = threading.Event()
             listener = threading.Thread(
@@ -130,6 +130,6 @@ class CANController:
           - https://python-can.readthedocs.io/en/master/
         """
         while not kill_threads.isSet():
-            msg = can_bus.recv()  # No timeout (wait indefinitely)
-            callback(message)
+            msg = can_bus.recv(1)  # 1 second receive timeout
+            if msg: callback(msg)
         can_bus.shutdown()

--- a/hardware_in_the_loop/software/hitl/iocontroller.py
+++ b/hardware_in_the_loop/software/hitl/iocontroller.py
@@ -276,17 +276,17 @@ class IOController:
         """
         response = int.from_bytes(value[1:], "big")  # first byte is special
 
-        mapped = (response - 0x0000) * (high - low) / (0xFFFF - 0x0000)
+        mapped = (response - 0x0000) * (high - low) / (0xFFFF - 0x0000) + low
 
         if not (low < mapped < high):
             raise Exception(
-                f"Value {value} not in range [{low}-{high}]! Invalid response received."
+                f"Value {mapped} not in range [{low}-{high}]! Invalid response received."
             )
-        if (response[0] & 0b10000000 == 0) and low > 0:
+        if (value[0] & 0b10000000 == 0) and low > 0:
             raise Exception(
                 f"Return value from ADC of {value} indicates the voltage was negative. See https://www.analog.com/media/en/technical-documentation/data-sheets/2489fb.pdf for details."
             )
-        if response[0] & 0b01000000 == 1:
+        if value[0] & 0b01000000 == 1:
             raise Exception(
                 f"Return value from ADC of {value} indicates the voltage measurement was clipped. See https://www.analog.com/media/en/technical-documentation/data-sheets/2489fb.pdf for details."
             )

--- a/hardware_in_the_loop/software/hitl/iocontroller.py
+++ b/hardware_in_the_loop/software/hitl/iocontroller.py
@@ -1,7 +1,38 @@
-# Imports
-import serial
+# IMPORTS
 import logging
 from typing import Tuple, Union
+
+import ft4222
+
+# CONSTANTS
+# ADC parameters
+ADC_CHANNEL_TO_ADD_BITS = {
+    0: 0b00000000,
+    1: 0b00001000,
+    2: 0b00000001,
+    3: 0b00001001,
+}
+ADC_PREFIX = 0b10110000
+ADC_RETURN_SIZE_BYTES = 3
+
+# DAC parameters
+DAC_CHANNEL_TO_ADD_BITS = {
+    i: i for i in range(8)
+}
+DAC_COMMANDS = {
+    "output now": 0b00110000,
+    "load but don't output": 0b00010000,
+    "output loaded values": 0b10110000,
+}
+
+# GPIO parameters
+GPIO_CHANNEL_TO_ADD_BITS = {
+    i: i for i in range(4, 32)
+}
+GPIO_COMMANDS = {
+    "single port": 0b00100000
+}
+GPIO_RETURN_SIZE_BYTES = 1
 
 
 class IOController:
@@ -11,28 +42,26 @@ class IOController:
     is configured using a ``.csv`` file, documented below. It allows a user to interact
     with our custom hardware by getting and setting digital and analog states.
 
-    `Confluence <https://docs.olinelectricmotorsports.com/display/AE/IO+Controller>`_
-
     :param str pin_info_path: The path to the pin_info file (should be stored in ``artifacts``).
-    :param str serial_path: The path to the serial device you are connecting to. If you are using
-        an arduino and have run ``scripts/hardware_setup.py``, then you should be able to use
-        ``/dev/arduino``. Otherwise, you might have to look for your device with ``$ ls /dev/*``
+    :param str device_description: The description of the device; used to connect.
     """
 
-    def __init__(self, pin_info_path: str, serial_path: str):
+    def __init__(self, pin_info_path: str, device_description: str = "FT4222 A"):
         # Create logger (all config should already be set by RoadkillHarness)
         self.log = logging.getLogger(name=__name__)
 
         self.pin_info = self._read_pin_info(path=pin_info_path)
         try:
-            self.serial = serial.Serial(port=serial_path, baudrate=115200, timeout=5)
-        except serial.serialutil.SerialException as e:
+            self.dev = ft4222.openByDescription(device_description)
+            self.dev.i2cMaster_Init(400_000)
+        except ft4222.FT2XXDeviceError as e:
             # Couldn't open the specified port; initialize w/o hardware for testing
-            self.log.error(f"Failed to connect to hardware at {serial_path}")
+            self.log.error(f"Failed to connect to device {device_description}")
             self.log.error(e)
-            self.serial = None
+            self.dev = None
 
-    def set_state(self, pin: str, value) -> None:
+
+    def set_state(self, name: str, value) -> None:
         """Set the value of an IO pin in the HitL system
 
         :param str pin: The name of the pin to update (e.x. THROTTLE_PEDAL_1)
@@ -41,101 +70,120 @@ class IOController:
 
         :returns: None
 
-        Message format:
-            4 bytes (all big endian)
+        DAC command message format (3 bytes):
+            
+            * bits 0-3: Operation type (see datasheet)
+            * bits 4-7: DAC number
+            * bits 8-23: Value to write
 
-            Byte 0:
-                * Bit 0: 0 (reserved bit)
-                * Bit 1: 1 (indicates a set request)
-                * Bits 2-7: Board number of the signal we want to get (0-63)
+        GPIO command message format (2 bytes):
+            * bits 0-2: Command type (see datasheet)
+            * bits 3-7: Pin number
+            * bits 8-14: Ignored
+            * bit 15: Value to write
 
-            Byte 1:
-                * Bits 0-7: Pin number of the signal we want to set
-
-            Bytes 2-3:
-                * Bits 0-15: 16 bit precision value to set, with 0% = 0x0000 and  100% = 0xFFFF
+        DAC Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5675.pdf
+        GPIO Datasheet: https://datasheets.maximintegrated.com/en/ds/MAX7300.pdf
         """
         # Raise an exception if the signal is read only
-        if self.pin[pin]["set_get"] == "GET":
-            raise Exception(f"{pin} is a read-only signal, you cannot set it!")
+        if self.pin[name]["read_write"] == "READ":
+            raise Exception(f"{name} is a read-only signal, you cannot set it!")
 
         # If no hardware, log an error
         if not self.serial:
             self.log.error("Could not set state; no hardware connection")
             return
 
-        # Byte 1
-        board = self.pin_info[pin]["board"] | (1 << 6)  # set the leftmost bit to 1 to designate message as setter
+        address = self.pin_info[name]["address"]
 
-        # Byte 2
-        pin_num = self.pin_info[pin]["pin"]
-
-        # Bytes 3-4
-        byte2 = 0  # most significant byte
-        byte3 = 0  # least significant byte
-
-        if self.pin_info[pin]["type"] == "DIGITAL":
-            if value == 1:
-                byte2 = byte3 = 0xFF  # oh yea, this syntax works :)
-        elif self.pin_info[pin]["type"] == "ANALOG":
-            byte2, byte3 = self._map_to_machine(value, self.pin_info[pin]["min"], self.pin_info[pin]["max"])
+        if self.pin_info[name]["type"] == "ANALOG":
+            byte1 = DAC_COMMANDS["output_now"] & DAC_CHANNEL_TO_ADD_BITS[self.pin_info[name]["pin"]]
+            byte2, byte3 = self._map_to_machine(
+                value=value,
+                low=self.pin_info[name]["min"],
+                high=self.pin_info[name]["max"]
+            )
+            data = bytes([byte1, byte2, byte3])
         else:
-            raise Exception(f"Unsupported signal type: {self.pin_info[pin]['type']}")
+            byte1 = GPIO_COMMANDS["single port"] & GPIO_CHANNEL_TO_ADD_BITS[self.pin.pin_info[name]["pin"]]
+            byte2 = 1 if value else 0
+            data = bytes([byte1, byte2])
 
-        request = bytes([board, pin_num, byte2, byte3])
-        self._send_request(request)
-        self.log.info(f"Set state of {pin} to {value}")
+        self.dev.i2cMaster_Write(address, data)
 
-    def get_state(self, pin: str) -> Union[int, float]:
+        self.log.info(f"Set state of {name} to {value}")
+
+
+    def get_state(self, name: str) -> Union[int, float]:
         """Request a hardware state from the HitL system.
 
-        :param str pin: The name of the state we want to get (e.x. "THROTTLE_POT_1", NOT 11)
+        :param str name: The name of the state we want to get (e.x. "THROTTLE_POT_1", NOT 11)
 
         :rtype:  Union[int, float]
         :returns: The value of the requested state. If the signal is analog, returns a ``float``, otherwise an ``int``.
 
-        Message format:
-            2 bytes (all big endian):
+        Getting an analog state is a 2 step process: we first write a command to the ADC to
+        start a conversion, then read the converted voltage back.
 
-            Byte 0:
-                * Bit 0: 0 (reserved bit)
-                * Bit 1: 0 (indicates a get request)
-                * Bits 2-7: Board number of the signal we want to get (0-63)
+        ADC command message format (1 byte):
 
-            Byte 1:
-                * Bits 0-7: Pin number of the signal we want to get
+            * bits 0-2
+                * 101 (enable setting a new input channel, we always do this)
+            * bit 3:
+                * 1 (single-ended comparison, not differential)
+            * bits 4-7
+                * 0000 for channel 0
+                * 1000 for channel 1
+                * 0001 for channel 2
+                * 1001 for channel 3
+
+        ADC data returned message format (3 bytes):
+
+            * bit 0: 1 if voltage was positive (relative to ground)
+            * bit 1: 1 if reading was out of bounds
+            * bits 2-7: 0
+            * bits 8-23: 16 bit voltage reading
+            
+
+        ADC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/2489fb.pdf
         """
         # Raise an exception if the signal is write only
-        if self.pin[pin]["set_get"] == "SET":
-            raise Exception(f"{pin} is a write-only signal, you cannot get it!")
+        if self.pin[name]["read_write"] == "WRITE":
+            raise Exception(f"{name} is a write-only signal, you cannot read it!")
             
         # If no hardware, log an error
         if not self.serial:
-            raise Exception("Could not get state, no hardware connection")
+            raise Exception("Could not get state, no hardware connection.")
 
         # Flush the serial buffer, in case anything has come in
         self.serial.flush()
 
         # Create and send request
-        board = self.pin_info[pin]["board"]
-        pin_num = self.pin_info[pin]["pin"]
-        request = bytes([board, pin_num])
-        self._send_request(request)
+        out = 0
+        address = self.pin_info[name]["address"]
+        
+        if self.pin_info[name]["type"] == "ANALOG":
+            # Request data
+            data = ADC_PREFIX & ADC_CHANNEL_TO_ADD_BITS[self.pin_info[name]["pin"]]
+            self.dev.i2cMaster_Write(address, data)
 
-        # Wait for response. We want this to block (which it does)
-        response = self.serial.read(size=2)  # Read 2 bytes
-        self.log.debug(f"Received {response}")
-
-        out = 0  # Type float or int
-        if self.pin_info[pin]["type"] == "DIGITAL":
-            out = 0 if int.from_bytes(response, "big") == 0 else 1
-        elif self.pin_info[pin]["type"] == "ANALOG":
-            out = self._map_to_human(response, self.pin_info[pin]["min"], self.pin_info[pin]["max"])
+            # Wait for response
+            response = self.dev.i2cMaster_Read(address, ADC_RETURN_SIZE_BYTES)
+            self.log.debug(f"Received {response}")
+            out = self._map_to_human(response, self.pin_info[name]["min"], self.pin_info[name]["max"])
         else:
-            raise Exception(f"Unsupported signal type: {self.pin_info[pin]['type']}")
+            # Request data
+            data = GPIO_COMMANDS["single port"] & GPIO_CHANNEL_TO_ADD_BITS[self.pin.pin_info[name]["pin"]]
+            self.dev.i2cMaster_Write(address, data)
 
-        self.log.info(f"Got state of {pin}: {out}")
+            # Wait for response
+            response = self.dev.i2cMaster_Read(address, GPIO_RETURN_SIZE_BYTES)
+            self.log.debug(f"Received {response}")
+            out = 1 if response else 0
+
+        self.log.info(f"Got state of {name}: {out}")
         return out
+
 
     def _read_pin_info(self, path: str) -> dict:
         """Read in the pin address information, given a path to a .csv file
@@ -143,9 +191,6 @@ class IOController:
         Args:
             path (str): The path to the .csv file containing pin information (see
             `software readme <https://github.com/olin-electric-motorsports/AdvancedResearch/tree/main/hardware_in_the_loop/software>`_
-            or
-            `google docs <https://docs.google.com/spreadsheets/d/15hpe0DXfQto9N2hawawvfeHTE1sq-UT7sgDl__hCTZ4/edit?usp=sharing>`_
-            for details)
 
         Returns:
             dict: A dictionary of (str: dict) pairs
@@ -155,34 +200,42 @@ class IOController:
             line = f.readline()  # clear the header line
             line = f.readline()  # get the first data line ready
             while line != "":  # keep reading until we hit the end
-                # parse line
                 data = line.split(",")
-                add = data[0].strip()
-                board = data[1].strip()
-                pin = data[2].strip()
-                sim = data[3].strip()
-                sig = data[4].strip()
-                sig_type = data[5].strip()
-                set_get = data[6].strip()
-                sig_min = data[7].strip()
-                sig_max = data[8].strip()
 
-                # add data to dictionary
+                # Parse a line of data
+                address    = data[0].strip()  # i2c address
+                pin        = data[1].strip()  # channel/pin number on chip
+                name       = data[2].strip()  # human-readable name of signal
+                type       = data[3].strip()  # analog or digital
+                read_write = data[4].strip()  # readable, writeable, or both
+                sig_min    = data[5].strip()  # min value of signal
+                sig_max    = data[6].strip()  # max value of signal
+
+                # Check for typos
+                if (int(address) > 127 or int(address) < 0): 
+                    raise Exception(f"I2C address of {address} for signal {name} is invalid!")
+                if type not in ["ANALOG", "DIGITAL"]: 
+                    raise Exception(f"Type {type} of signal {name} is invalid! Please use ANALOG or DIGITAL")
+                if read_write not in ["READ", "WRITE", "BOTH"]:
+                    raise Exception(f"Read/write value {read_write} of signal {name} is invalid! Please use READ, WRITE, or BOTH")
+
+                # Add data to dictionary
                 sig_dict = {}
-                sig_dict["address"] = int(add)
-                sig_dict["board"] = int(add)
-                sig_dict["pin"] = int(add)
-                sig_dict["simulator"] = sim
-                sig_dict["type"] = sig_type
-                sig_dict["set_get"] = set_get
-                sig_dict["min"] = float(sig_min)
-                sig_dict["max"] = float(sig_max)
-                out[sig] = sig_dict
+
+                sig_dict["address"]    = int(address)
+                sig_dict["pin"]        = int(pin)
+                sig_dict["type"]       = type
+                sig_dict["read_write"] = read_write
+                sig_dict["min"]        = float(sig_min)
+                sig_dict["max"]        = float(sig_max)
+
+                out[name] = sig_dict
 
                 # read new line
                 line = f.readline()
 
         return out
+
 
     def _map_to_machine(self, value: float, low: float, high: float) -> Tuple[int, int]:
         """Map from a floating point value to a 16 bit precision value, from min to max
@@ -203,35 +256,32 @@ class IOController:
         byte1 = mapped & 0x00FF
         return byte0, byte1
 
+
     def _map_to_human(self, value: bytes, low: float, high: float) -> float:
-        """Inverse of map to machine; convert from 2 bytes to a float
+        """Convert from 2 bytes returned from an ADC to a float (voltage)
 
         Args:
             value (float): The bytes received
-            low, high (floats): The min and max acceptable voltages
+            low, high (floats): The voltages of the high and low rails of the ADC
 
             Example: _map_to_human(b'\x00\xff', 0, 5) -> 2.5
 
         Returns:
             float: The voltage of the pin
         """
-        response = int.from_bytes(value, "big")
+        response = int.from_bytes(value[1:], "big")  # first byte is special
 
         mapped = (response - 0x0000) * (high - low) / (0xFFFF - 0x0000)
 
         if not (low < mapped < high):
-            raise Exception(f"Value {value} not in range [{low}-{high}]! Invalid response received")
+            raise Exception(f"Value {value} not in range [{low}-{high}]! Invalid response received.")
+        if (response[0] & 0b10000000 == 0) and low > 0:
+            raise Exception(f"Return value from ADC of {value} indicates the voltage was negative. See https://www.analog.com/media/en/technical-documentation/data-sheets/2489fb.pdf for details.")
+        if response[0] & 0b01000000 == 1: 
+            raise Exception(f"Return value from ADC of {value} indicates the voltage measurement was clipped. See https://www.analog.com/media/en/technical-documentation/data-sheets/2489fb.pdf for details.")
 
         return mapped
 
-    def _send_request(self, request: bytes) -> None:
-        """Send a request over serial to set a pin's value
-
-        Args:
-            request (bytes): The bytes to send
-        """
-        self.log.debug(f"Sent {request}")
-        self.serial.write(request)
 
     def __enter__(self) -> None:
         """Enter and exit functions allow signals to be set simultaneously with hardware
@@ -259,19 +309,21 @@ class IOController:
         minimizing any delay introduced by the serial communication/sequential
         function calls.
         """
-        self._send_request(bytes([0xFF]))
+        raise Exception("Not implemented")
+
 
     def __exit__(self) -> None:
         """See docstring for __enter__ above
 
         Send 0xFF byte to system interface
         """
-        self._send_request(bytes([0xFF]))
+        raise Exception("Not implemented")
+
 
     def __del__(self) -> None:
         """Destructor (called when the program ends)
 
         Close the serial port for a clean teardown
         """
-        if self.serial:
-            self.serial.close()
+        if self.dev:
+            self.dev.close()

--- a/hardware_in_the_loop/software/hitl/roadkillharness.py
+++ b/hardware_in_the_loop/software/hitl/roadkillharness.py
@@ -37,8 +37,10 @@ class RoadkillHarness:
         # Create IOController
         self.log.info("Creating IOController...")
         self.io = IOController(
-            pin_info_path=os.path.join(artifacts_path, config.get("PATHS", "pin_config", fallback="pin_info.csv")),
-            serial_path=config.get("PATHS", "serial_path", fallback="/dev/arduino"),
+            pin_info_path=os.path.join(
+                artifacts_path,
+                config.get("PATHS", "pin_config", fallback="pin_info.csv"),
+            )
         )
 
         # Create all ECUs

--- a/hardware_in_the_loop/software/hitl/test.py
+++ b/hardware_in_the_loop/software/hitl/test.py
@@ -9,7 +9,9 @@ class Tester:
     def __init__(self):
         global kill_threads
         kill_threads = False
-        thread = threading.Thread(target=self.thread, kwargs={"callback": self.callback})
+        thread = threading.Thread(
+            target=self.thread, kwargs={"callback": self.callback}
+        )
         thread.start()
         time.sleep(5)
         kill_threads = True

--- a/hardware_in_the_loop/software/hitl/utils.py
+++ b/hardware_in_the_loop/software/hitl/utils.py
@@ -9,7 +9,9 @@ from typing import Tuple, Optional
 
 
 # Constant definitions
-root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))  # to software
+root_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir)
+)  # to software
 artifacts_path = os.path.join(root_path, "artifacts")
 
 
@@ -34,11 +36,17 @@ def get_logging_config() -> None:
         log_path = None
 
     if log_path:
-        log_path = log_path.replace("$DATETIME", datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S"))
+        log_path = log_path.replace(
+            "$DATETIME", datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        )
         log_path = log_path.replace("$LOGS", os.path.join(artifacts_path, "logs"))
 
     logging.basicConfig(
-        format=config.get("LOGGING", "log_format", fallback="%(asctime)s - %(name)s - %(levelname)s - %(message)s"),
+        format=config.get(
+            "LOGGING",
+            "log_format",
+            fallback="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        ),
         level=config.get("LOGGING", "log_level", fallback="INFO"),
         filename=log_path,
     )

--- a/hardware_in_the_loop/software/requirements.txt
+++ b/hardware_in_the_loop/software/requirements.txt
@@ -1,3 +1,4 @@
+ft4222
 python-can==3.3.4
 pyserial==3.4
 pytest==6.1.1

--- a/hardware_in_the_loop/software/setup.py
+++ b/hardware_in_the_loop/software/setup.py
@@ -14,6 +14,7 @@ setup(
     version="0.1.0",
     packages=find_packages(include=["hitl", "hitl.*"]),
     install_requires=[
+        "ft4222=1.2.2",
         "python-can>=3.3.4",
         "pyserial>=3.4",
         "pytest>=6.1.1",

--- a/hardware_in_the_loop/software/tests/unit/sample_io_addresses.csv
+++ b/hardware_in_the_loop/software/tests/unit/sample_io_addresses.csv
@@ -1,4 +1,4 @@
-Address,Board,Pin,Simulator,Name,Type,Min,Max,Notes
-0,0,0,EXAMPLE1,EXAMPLE_DIGITAL_SIGNAL,DIGITAL,0,1,None
-1,0,1,EXAMPLE1,EXAMPLE_ANALOG_SIGNAL,ANALOG,0,5,None
-2,0,2,ARDUINO,ARDUINO_STATE,ANALOG,0,5,None
+Address ,Pin Number ,Name                   ,Type    ,Read/Write ,Min ,Max ,Notes
+0       ,0          ,EXAMPLE_DIGITAL_SIGNAL ,DIGITAL ,READ       ,0   ,1   ,None
+1       ,1          ,EXAMPLE_ANALOG_SIGNAL  ,ANALOG  ,READ       ,0   ,5   ,None
+2       ,2          ,ARDUINO_STATE          ,ANALOG  ,READ       ,0   ,5   ,None

--- a/hardware_in_the_loop/software/tests/unit/test_can.py
+++ b/hardware_in_the_loop/software/tests/unit/test_can.py
@@ -29,7 +29,7 @@ def can():
     out = CANController(
         ecus=ecus,
         can_spec_path=path,
-        channel=config.get("HARDWARE", "can_channel", fallback="can0"),
+        channel=config.get("HARDWARE", "can_channel", fallback="vcan0"),
         bitrate=config.get("HARDWARE", "can_bitrate", fallback="500000"),
     )
 

--- a/hardware_in_the_loop/software/tests/unit/test_io.py
+++ b/hardware_in_the_loop/software/tests/unit/test_io.py
@@ -16,10 +16,7 @@ config.read(os.path.join(artifacts_path, "config.ini"))
 @pytest.fixture
 def io():
     path = os.path.abspath(os.path.dirname(__file__) + "/sample_io_addresses.csv")
-    out = IOController(
-        pin_info_path=path,
-        serial_path=config.get("PATHS", "serial_path", fallback="/dev/arduino"),
-    )
+    out = IOController(pin_info_path=path)
     time.sleep(2)  # Was seeing weird errors without this
     return out
 

--- a/hardware_in_the_loop/software/tests/unit/test_io.py
+++ b/hardware_in_the_loop/software/tests/unit/test_io.py
@@ -13,7 +13,7 @@ config = ConfigParser(interpolation=None)
 config.read(os.path.join(artifacts_path, "config.ini"))
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def io():
     path = os.path.abspath(os.path.dirname(__file__) + "/sample_io_addresses.csv")
     out = IOController(pin_info_path=path)
@@ -33,7 +33,7 @@ def logger():
 def test_connected(io, logger):
     # Create an IOController to make sure it can connect to hardware!
     logger.info("Testing hardware connection...")
-    assert io.serial
+    assert io.dev
 
 
 @pytest.mark.soft
@@ -47,24 +47,7 @@ def test_read_io_file(io, logger):
 
     digital = io.pin_info["EXAMPLE_DIGITAL_SIGNAL"]
     assert digital["min"] == 0
-    assert digital["simulator"] == "EXAMPLE1"
-
-
-@pytest.mark.hard
-@pytest.mark.unit
-def test_get_set(io, logger):
-    # Assumes plugged into arduino running `firmware/arduino/hitl_interface_mock.ino`
-    logger.info("Testing send/receive functionality...")
-
-    io.set_state("ARDUINO_STATE", 1)
-    time.sleep(1)
-    assert 0.99 < io.get_state("ARDUINO_STATE") < 1.01
-
-    time.sleep(1)
-
-    io.set_state("ARDUINO_STATE", 2)
-    time.sleep(1)
-    assert 1.99 < io.get_state("ARDUINO_STATE") < 2.01
+    assert digital["pin"] == 0
 
 
 @pytest.mark.soft
@@ -84,4 +67,10 @@ def test_encoder(io, logger):
 @pytest.mark.soft
 @pytest.mark.unit
 def test_decoder(io, logger):
-    assert True
+    logger.info("Testing decoder (_map_to_human())...")
+
+    v1 = io._map_to_human(bytes([0x80, 0x33, 0x33]), 2.5, 5)
+    assert v1 == pytest.approx(3.0, abs=0.01)
+
+    v2 = io._map_to_human(bytes([0x80, 0x7F, 0xFF]), 0, 5)
+    assert v2 == pytest.approx(2.5, abs=0.01)

--- a/hardware_in_the_loop/software/tests/unit/test_utils.py
+++ b/hardware_in_the_loop/software/tests/unit/test_utils.py
@@ -27,13 +27,3 @@ def test_pad_zeros(logger):
 
     assert pad_with_zeros("42", 4) == "0042"
     assert pad_with_zeros("1234", 4) == "1234"
-
-
-@pytest.mark.soft
-@pytest.mark.hard
-def test_find_arduino(logger):
-    logger.info("Testing find_arduino...")
-
-    idVendor, idProduct = find_arduino()
-    assert idVendor != None
-    assert idProduct != None


### PR DESCRIPTION
First pass at refactoring the `IOController` for use with the FT4222 (USB to I2C) chip. Not validated (I won't get a chance to do that until I have hardware), but I'd like to get this change in before we migrate to the monorepo.
